### PR TITLE
TwinkleConfig: Add showPrefLink option

### DIFF
--- a/modules/twinkleconfig.js
+++ b/modules/twinkleconfig.js
@@ -155,6 +155,11 @@ TwinkleGlobal.config.sections = [
 				name: 'dialogLargeFont',
 				label: 'Use larger text in Twinkle dialogs',
 				type: 'boolean'
+			},
+			{
+				name: 'showPrefLink',
+				label: 'Include a link to the preference page in the dropdown menu',
+				type: 'boolean'
 			}
 		]
 	},

--- a/twinkle.js
+++ b/twinkle.js
@@ -50,6 +50,8 @@ TwinkleGlobal.defaultConfig = {
 	protectionSummaryAd: ' (TwinkleGlobal)',
 	userTalkPageMode: 'tab',
 	dialogLargeFont: false,
+	showPrefLink: true,
+	
 
 	// GARV
 	spiWatchReport: 'yes',
@@ -480,7 +482,9 @@ TwinkleGlobal.load = function () {
 		// TwinkleGlobal.batchundelete();
 	}
 
-	TwinkleGlobal.addPortletLink(TwinkleGlobal.getPref('configPage'), 'Pref', 'twg-config', 'Set Twinkle preferences');
+	if (TwinkleGlobal.getPref('showPrefLink')) {
+		TwinkleGlobal.addPortletLink(TwinkleGlobal.getPref('configPage'), 'Pref', 'twg-config', 'Set Twinkle preferences');
+	}
 
 	// Run the initialization callbacks for any custom modules
 	TwinkleGlobal.initCallbacks.forEach(function (func) {

--- a/twinkle.js
+++ b/twinkle.js
@@ -51,7 +51,6 @@ TwinkleGlobal.defaultConfig = {
 	userTalkPageMode: 'tab',
 	dialogLargeFont: false,
 	showPrefLink: true,
-	
 
 	// GARV
 	spiWatchReport: 'yes',


### PR DESCRIPTION
I don't like it showing up each time, especially since, depending on load order, it moves around. Its unneeded, but since users are already used to it, make it an option that is enabled by default