### PR TITLE
twinkle.js: add vector-menu-heading to vector dropdown label

### DIFF
--- a/twinkle.js
+++ b/twinkle.js
@@ -337,6 +337,7 @@ TwinkleGlobal.addPortlet = function(navigation, id, text, type, nextnodeid) {
 
 	if (skin === 'vector' || skin === 'vector-2022') {
 		ul.className = 'vector-menu-content-list';
+		h3.className = 'vector-menu-heading';
 
 		// add invisible checkbox to keep menu open when clicked
 		// similar to the p-cactions ("More") menu


### PR DESCRIPTION
Changes in T290280 (ab11cc9adb8124d93659aca6491b36298d5dc27a) broke the
styling for the Vector dropdown menu. Adding vector-menu-heading is
required now for correct styling. The h3 element is still used for
Timeless compatibility.