### PR TITLE
Remove dewikibooks from nonGSWikis

### DIFF
--- a/morebits.js
+++ b/morebits.js
@@ -138,7 +138,6 @@ MorebitsGlobal.nonGSWikis = [
 	'cywiki',
 	'dawiki',
 	'dewiki',
-	'dewikibooks',
 	'dewikisource',
 	'dewikivoyage',
 	'dewiktionary',


### PR DESCRIPTION
Please remove dewikibooks (German Wikibooks) from nonGSWikis per [this link](https://meta.wikimedia.org/w/index.php?oldid=30068041). Thanks.